### PR TITLE
Work around the limitations we find with String in Substrate

### DIFF
--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -15,6 +15,8 @@ version = "14.1.0"
 [features]
 default = ["std"]
 
+codec = ["ethereum-types/codec"]
+
 std = [
 	"anyhow/std",
 	"hex/std",
@@ -27,7 +29,7 @@ std = [
 
 [dependencies]
 anyhow         = { version = "1.0.42", default-features = false }
-ethereum-types = { version = "0.12.0", default-features = false }
+ethereum-types = { version = "0.11.0", default-features = false, features = ["codec"] }
 hex            = { version = "0.4.3", default-features = false, features = ["alloc"] }
 serde          = { version = "1.0.126", features = ["derive"], optional = true }
 serde_json     = { version = "1.0.64", optional = true }

--- a/ethabi/src/function.rs
+++ b/ethabi/src/function.rs
@@ -43,24 +43,26 @@ pub struct Function {
 
 impl Function {
 	/// Construct a Function working around the String limitations of Substrate
-	pub fn new(new_name: &str, inputs: Vec<Param>, outputs: Vec<Param>, constant: bool) -> Self {
+	pub fn new(new_name: &str, inputs: Vec<Param>, outputs: Vec<Param>, constant: bool, state_mutability: StateMutability) -> Self {
 		Function {
 			name: new_name.into(),
 			inputs,
 			outputs,
 			constant,
+			state_mutability,
 		}
 	}
 }
 
 /// Construct a Function from tuple working around the String limitations of Substrate
-impl From<(String, Vec<Param>, Vec<Param>, bool)> for Function {
-	fn from(params: (String, Vec<Param>, Vec<Param>, bool)) -> Self {
+impl From<(String, Vec<Param>, Vec<Param>, bool, StateMutability)> for Function {
+	fn from(params: (String, Vec<Param>, Vec<Param>, bool, StateMutability)) -> Self {
 		Function {
 			name: params.0.into(),
 			inputs: params.1,
 			outputs: params.2,
 			constant: params.3,
+			state_mutability: params.4,
 		}
 	}
 }

--- a/ethabi/src/function.rs
+++ b/ethabi/src/function.rs
@@ -33,6 +33,30 @@ pub struct Function {
 }
 
 impl Function {
+	/// Construct a Function working around the String limitations of Substrate
+	pub fn new(new_name: &str, inputs: Vec<Param>, outputs: Vec<Param>, constant: bool) -> Self {
+		Function {
+			name: new_name.into(),
+			inputs,
+			outputs,
+			constant,
+		}
+	}
+}
+
+/// Construct a Function from tuple working around the String limitations of Substrate
+impl From<(String, Vec<Param>, Vec<Param>, bool)> for Function {
+	fn from(params: (String, Vec<Param>, Vec<Param>, bool)) -> Self {
+		Function {
+			name: params.0.into(),
+			inputs: params.1,
+			outputs: params.2,
+			constant: params.3,
+		}
+	}
+}
+
+impl Function {
 	/// Returns all input params of given function.
 	fn input_param_types(&self) -> Vec<ParamType> {
 		self.inputs.iter().map(|p| p.kind.clone()).collect()

--- a/ethabi/src/param.rs
+++ b/ethabi/src/param.rs
@@ -30,6 +30,25 @@ pub struct Param {
 	pub kind: ParamType,
 }
 
+impl Param {
+	/// Construct a Param working around the String limitations of Substrate
+	pub fn new(new_name: &str, kind: ParamType) -> Self {
+		Param {
+			name: new_name.into(),
+			kind,
+		}
+	}
+}
+// no_std friendly coming from Substrate
+impl From<(&str, ParamType)> for Param {
+	fn from(param: (&str, ParamType)) -> Self {
+		Param {
+			name: param.0.into(),
+			kind: param.1,
+		}
+	}
+}
+
 #[cfg(feature = "std")]
 impl<'a> Deserialize<'a> for Param {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>


### PR DESCRIPTION
Using `String`  in Substrate's runtime isn't the easiest thing to do.  A few updates to allow us to work with `&str`  and use `ethabi` from the Runtime(WASM)

It allows us now to build `Function`  structs in the substrate runtime as follows: 

```
let call_me_fn = Function::new(
           "claimThis",
            vec![
	        Param::new("UniqueID", ParamType::FixedBytes(32)),
	        Param::new("amount", ParamType::Uint(64)),
	    ],
	    vec![],
	    false,
);
```