### PR TITLE
ink! contracts no_std usage support

### DIFF
--- a/ethabi/Cargo.toml
+++ b/ethabi/Cargo.toml
@@ -13,7 +13,7 @@ name = "ethabi"
 version = "14.1.0"
 
 [features]
-default = ["std"]
+default = ["std", "sha3"]
 
 std = [
 	"anyhow/std",
@@ -31,7 +31,7 @@ ethereum-types = { version = "0.12.0", default-features = false }
 hex            = { version = "0.4.3", default-features = false, features = ["alloc"] }
 serde          = { version = "1.0.126", features = ["derive"], optional = true }
 serde_json     = { version = "1.0.64", optional = true }
-sha3           = { version = "0.9.1", default-features = false }
+sha3           = { version = "0.9.1", default-features = false, optional = true }
 thiserror      = { version = "1.0.26", optional = true }
 uint           = { version = "0.9.1", default-features = false }
 

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -5,7 +5,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+#![cfg(feature = "sha3")]
 #[cfg(feature = "std")]
 use crate::operation::Operation;
 use crate::{errors, Constructor, Error, Event, Function};

--- a/ethabi/src/event.rs
+++ b/ethabi/src/event.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 //! Contract event.
+#![cfg(feature = "sha3")]
 
 #[cfg(not(feature = "std"))]
 use alloc::{collections::BTreeMap, string::String, vec::Vec};

--- a/ethabi/src/function.rs
+++ b/ethabi/src/function.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 //! Contract function call builder.
-
+#![cfg(feature = "sha3")]
 use crate::{
 	decode, encode, signature::short_signature, Bytes, Error, Param, ParamType, Result, StateMutability, Token,
 };

--- a/ethabi/src/lib.rs
+++ b/ethabi/src/lib.rs
@@ -42,17 +42,20 @@ mod util;
 mod tests;
 
 pub use ethereum_types;
+#[cfg(feature = "sha3")]
+pub use crate::event::Event;
+#[cfg(feature = "sha3")]
+pub use crate::function::Function;
+#[cfg(feature = "sha3")]
+pub use crate::contract::{Contract, Events, Functions};
 
 pub use crate::{
 	constructor::Constructor,
-	contract::{Contract, Events, Functions},
 	decoder::decode,
 	encoder::encode,
 	errors::{Error, Result},
-	event::Event,
 	event_param::EventParam,
 	filter::{RawTopicFilter, Topic, TopicFilter},
-	function::Function,
 	log::{Log, LogFilter, LogParam, ParseLog, RawLog},
 	param::Param,
 	param_type::ParamType,

--- a/ethabi/src/signature.rs
+++ b/ethabi/src/signature.rs
@@ -5,6 +5,7 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![cfg(feature = "sha3")]
 
 use crate::{
 	param_type::{ParamType, Writer},


### PR DESCRIPTION
This PR enables usage of ethabi library in ink! smart contracts.
Previously, the `sha3` import broke the build in ink! contracts, since `ink_env` crate contains optional `sha3` [import](https://github.com/paritytech/ink/blob/a45d48c14f41de0fd8881509070ca2ccd913873e/crates/env/Cargo.toml#L35). 
By adding some `#[cfg(feature = "sha3")]` annotations, this PR disables some functionality related to contracts and signatures (when the `sha3` feature is disabled), but allows usage of the rest of the library in ink! contracts.